### PR TITLE
Add default setting values if undefined

### DIFF
--- a/rule.php
+++ b/rule.php
@@ -214,7 +214,11 @@ class quizaccess_hidecorrect extends quiz_access_rule_base {
     public static function save_settings($quiz) {
         global $DB;
 
-        $data = (object) ['hidecorrect' => $quiz->hidecorrect, 'autograde' => $quiz->hidecorrect_autograde];
+        // Default values to false if hidecorrect property is undefined
+        $hidecorrect = $quiz->hidecorrect ?? false;
+        $autograde = $quiz->hidecorrect_autograde ?? false;
+
+        $data = (object) ['hidecorrect' => $hidecorrect, 'autograde' => $autograde];
 
         if ($record = $DB->get_record('quizaccess_hidecorrect', ['quizid' => $quiz->id])) {
             $data->id = $record->id;


### PR DESCRIPTION
Linking issue #6 

It looks like this fixes the issue. I have retested unit tests and grade setting saving from the user interface.

Before fix:
```
There were 83 errors:

1) core\grade_category_test::test_grade_category
Undefined property: stdClass::$hidecorrect

/var/www/site/mod/quiz/accessrule/hidecorrect/rule.php:217
/var/www/site/mod/quiz/accessmanager.php:156
/var/www/site/mod/quiz/lib.php:1195
/var/www/site/mod/quiz/lib.php:106
/var/www/site/course/modlib.php:137
/var/www/site/lib/testing/generator/module_generator.php:278
/var/www/site/mod/quiz/tests/generator/lib.php:100
/var/www/site/lib/testing/generator/data_generator.php:503
/var/www/site/lib/grade/tests/fixtures/lib.php:104
/var/www/site/lib/grade/tests/fixtures/lib.php:73
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:97
```

After fix:
```
root@c6158c56e24c:/var/www/moodle-41-site# vendor/bin/phpunit --testsuite core_grades_testsuite
Moodle 4.1.10+ (Build: 20240510), ff50214601f73056ed3f2a2acdf5abcdbb291f68
Php: 7.4.33, mysqli: 8.0.34, OS: Linux 6.5.0-28-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

...............................................................  63 / 200 ( 31%)
............................................................... 126 / 200 ( 63%)
............................................................... 189 / 200 ( 94%)
...........                                                     200 / 200 (100%)

Time: 05:35.272, Memory: 119.00 MB

OK (200 tests, 2315 assertions)
```